### PR TITLE
Feature/fix image update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-.history
-password.txt
-vulnerability-reports/
-.DS_Store
-# nightingale-go
-.github/workflows/test.txt
-nightingale-go/dist
-test
+vulnerability
+docker compose/nginx/certs
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+.history
+password.txt
+vulnerability-reports/
+.DS_Store
+# nightingale-go
+.github/workflows/test.txt
+nightingale-go/dist
+test
+gui
 vulnerability
 docker compose/nginx/certs
-

--- a/docker compose/.env.arm64.example
+++ b/docker compose/.env.arm64.example
@@ -1,0 +1,2 @@
+# .env.arm64
+NIGHTINGALE_TAG=arm64

--- a/docker compose/.env.stable.example
+++ b/docker compose/.env.stable.example
@@ -1,0 +1,2 @@
+# .env.stable
+NIGHTINGALE_TAG=stable

--- a/docker compose/docker-compose.yaml
+++ b/docker compose/docker-compose.yaml
@@ -1,0 +1,24 @@
+# docker-compose.yml
+version: '3.8'
+
+services:
+  nightingale:
+    image: ghcr.io/rajanagori/nightingale:${NIGHTINGALE_TAG}
+    container_name: nightingale-${NIGHTINGALE_TAG}
+    command: ["ttyd", "-p", "7681", "bash"]
+    ports:
+      - "8080:7681"
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    depends_on:
+      - nightingale
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+    restart: unless-stopped

--- a/docker compose/nginx/nginx.conf
+++ b/docker compose/nginx/nginx.conf
@@ -1,0 +1,42 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    upstream nightingale {
+        # inside Docker network, refer to service name and container port
+        server nightingale:7681;
+    }
+
+    # Redirect HTTP to HTTPS
+    server {
+        listen 80;
+        server_name localhost;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /etc/nginx/certs/selfsigned.crt;
+        ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        location / {
+            proxy_pass http://nightingale;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+    }
+}

--- a/nightingale-go/go.mod
+++ b/nightingale-go/go.mod
@@ -4,10 +4,7 @@ go 1.23.0
 
 toolchain go1.23.6
 
-require (
-	github.com/schollz/progressbar/v3 v3.18.0
-	golang.org/x/text v0.23.0
-)
+require github.com/schollz/progressbar/v3 v3.18.0
 
 require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect

--- a/nightingale-go/go.sum
+++ b/nightingale-go/go.sum
@@ -18,7 +18,5 @@ golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
 golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## 📦 Summary

This PR introduces two main improvements:

1. **Dependency management**  
   - Tidies up `go.mod` & `go.sum` by removing duplicate and unused entries (chore).

2. **Docker-Compose + Nginx support**  
   - Adds a `docker-compose.yml` to spin up Nightingale and an Nginx reverse proxy.  
   - Parameterizes the Nightingale image tag via `.env.arm64.example` and `.env.stable.example`.  
   - Provides an `nginx/nginx.conf` that:  
     - Redirects HTTP (port 80) → HTTPS (port 443)  
     - Terminates SSL with a self-signed cert  
     - Proxies `/` to the Nightingale ttyd service  

---

## 🛠 Changes

- **chore**: update `go.mod` and `go.sum` to streamline dependencies  
- **feat**: add `docker-compose.yml`  
- **feat**: add `.env.arm64.example` & `.env.stable.example`  
- **feat**: add `nginx/nginx.conf` for HTTPS reverse-proxy setup  
- **perf**: trim `.gitignore` to exclude old artifacts and secrets  

---

## 🚀 Testing

1. Copy either `.env.*.example` → `.env` and choose your tag (`arm64` or `stable`).  
2. Run `docker-compose up -d`  
3. Visit <https://localhost> (ignore your browser’s cert warning, or install the matching `.crt`)  
4. Verify you see the Nightingale terminal served over HTTPS.

---

## ✅ Checklist

- [x] `go mod tidy` passes  
- [x] Containers start without error  
- [x] HTTPS endpoint responds and proxies correctly  

---

## 🔒 Security & Clean-up

- **Private key** (`selfsigned.key`) is excluded via `.gitignore`  
- **Public cert** may be checked in or generated at runtime per your preference  

---

## 🎯 Closing

Closes #\<issue-number\>  
*(replace `<issue-number>` with the issue tracking this work)*  