### PR TITLE
Add Dependabot configuration for automated weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "docker"        # Docker (supports v1)
+    directory: "/"                     # Location of Dockerfile(s)
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker-compose"  # Docker Compose (supports v2, v3)
+    directory: "/"                       # Location of docker-compose.yml
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "helm"           # Helm Charts (supports v3)
+    directory: "/"                      # Location of Chart.yaml
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gitsubmodule"   # Git submodules
+    directory: "/"                      # Location of .gitmodules
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions" # GitHub Actions workflows
+    directory: "/"                      # Location of .github/workflows
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"          # Go modules (v1)
+    directory: "/"                      # Location of go.mod
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"            # npm (supports v7, v8, v9)
+    directory: "/"                      # Location of package.json
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"            # pip (v21.1.2)
+    directory: "/"                      # Location of requirements.txt
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"            # pipenv (Pipfile, <=2021-05-29)
+    directory: "/"                      # Location of Pipfile
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Description

This PR adds a new Dependabot configuration file (.github/dependabot.yml) to enable automated, weekly dependency version checks and update PRs across our various ecosystems:
	•	Docker (docker)
	•	Docker Compose (docker-compose)
	•	Helm Charts (helm)
	•	Git submodules (gitsubmodule)
	•	GitHub Actions (github-actions)
	•	Go modules (gomod)
	•	npm (npm)
	•	pip (pip)
	•	Pipenv (also using the pip ecosystem for the Pipfile)

Each ecosystem is scheduled to be checked once per week for new versions of its respective manifests (Dockerfiles, Helm charts, go.mod, package.json, requirements.txt, Pipfile, etc.).

⸻

Motivation

Keeping dependencies up-to-date is critical for:
	•	Security: Automatically catch and remediate known vulnerabilities.
	•	Stability: Ensure we’re using the latest bug fixes and performance improvements.
	•	Maintainability: Reduce the manual overhead of tracking new releases for multiple ecosystems.

Dependabot will open PRs against the default branch for any detected updates, streamlining our update workflow.

⸻

Changes
	•	Added .github/dependabot.yml with version 2.
	•	Configured nine package-ecosystems, each set to check the repository root (/) on a weekly schedule.
	•	Specified the correct ecosystems and manifest locations:
	•	docker → Dockerfiles
	•	docker-compose → docker-compose.yml
	•	helm → Chart.yaml
	•	gitsubmodule → .gitmodules
	•	github-actions → GitHub workflows
	•	gomod → go.mod
	•	npm → package.json
	•	pip → requirements.txt
	•	pip (for Pipenv) → Pipfile