### PR TITLE
fix(security): disable CGO during Go tool rebuild

### DIFF
--- a/configuration/cve-mitigation/rebuild-go-binaries.sh
+++ b/configuration/cve-mitigation/rebuild-go-binaries.sh
@@ -8,6 +8,7 @@
 set -euo pipefail
 
 export GOTOOLCHAIN=local
+export CGO_ENABLED="${CGO_ENABLED:-0}"
 export GOPATH="${GOPATH:-/home/go}"
 export GOROOT="${GOROOT:-/usr/local/go}"
 export PATH="${GOROOT}/bin:${GOPATH}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
## Summary
Fixes the stable Docker build failure in [run #390](https://github.com/RAJANAGORI/Nightingale/actions/runs/28305025346) where `rebuild-go-binaries.sh --audit` failed with:

```
fatal error: stdlib.h: No such file or directory
```

The final stage purges `linux-libc-dev` (and autoremove drops C headers) before the Go rebuild runs. Setting `CGO_ENABLED=0` avoids needing those headers, consistent with `install-gitleaks.sh`.

## Test plan
- [ ] Re-run **Docker Image stable** workflow after merge
- [ ] Re-run **Docker Image ARM64** workflow (prior failure was a transient Docker Hub timeout)


Made with [Cursor](https://cursor.com)