### PR TITLE
fix(ci): expand IMAGE_TAG via named stages and drop Buildx install

### DIFF
--- a/.github/actions/build-push-sign/action.yml
+++ b/.github/actions/build-push-sign/action.yml
@@ -19,8 +19,12 @@ inputs:
   driver:
     description: Buildx driver from docker-login-buildx; GHA cache is skipped for docker.
     required: true
-  build-args:
-    description: Optional KEY=value lines for docker/build-push-action.
+  arch:
+    description: Value for the Dockerfile ARCH build-arg (amd64 or arm64).
+    required: false
+    default: amd64
+  extra-apt-packages:
+    description: Value for EXTRA_APT_PACKAGES, for example netcat-openbsd on ARM64.
     required: false
     default: ''
   registry:
@@ -47,7 +51,11 @@ runs:
         sbom: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        build-args: ${{ inputs.build-args }}
+        build-args: |
+          IMAGE_TAG=${{ inputs.image-tag }}
+          BASE_TAG=${{ inputs.image-tag }}
+          ARCH=${{ inputs.arch }}
+          EXTRA_APT_PACKAGES=${{ inputs.extra-apt-packages }}
         tags: |
           ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
           ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.commit-hash }}
@@ -63,7 +71,11 @@ runs:
         push: true
         provenance: mode=max
         sbom: true
-        build-args: ${{ inputs.build-args }}
+        build-args: |
+          IMAGE_TAG=${{ inputs.image-tag }}
+          BASE_TAG=${{ inputs.image-tag }}
+          ARCH=${{ inputs.arch }}
+          EXTRA_APT_PACKAGES=${{ inputs.extra-apt-packages }}
         tags: |
           ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
           ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.commit-hash }}

--- a/.github/actions/docker-login-buildx/action.yml
+++ b/.github/actions/docker-login-buildx/action.yml
@@ -66,7 +66,6 @@ runs:
       with:
         buildkitd-flags: --oci-worker-gc --oci-worker-gc-keepstorage 8000000000
         driver: docker-container
-        install: true
         use: true
 
     - name: Check Buildx driver

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -109,7 +109,6 @@ jobs:
         image-tag: stable
         commit-hash: ${{ env.COMMIT_HASH }}
         driver: ${{ steps.setup.outputs.driver }}
-        build-args: BASE_TAG=stable
 
   build-main:
     needs: build-dependent
@@ -144,9 +143,7 @@ jobs:
         image-tag: stable
         commit-hash: ${{ env.COMMIT_HASH }}
         driver: ${{ steps.setup.outputs.driver }}
-        build-args: |
-          IMAGE_TAG=stable
-          ARCH=amd64
+        arch: amd64
 
     - name: Audit Go stdlib in final image
       if: ${{ github.event_name == 'schedule' || inputs.build_type == 'all' }}

--- a/.github/workflows/multi-os-arm64.yaml
+++ b/.github/workflows/multi-os-arm64.yaml
@@ -109,7 +109,6 @@ jobs:
         image-tag: arm64
         commit-hash: ${{ env.COMMIT_HASH }}
         driver: ${{ steps.setup.outputs.driver }}
-        build-args: BASE_TAG=arm64
 
   build-main:
     needs: build-dependent
@@ -145,10 +144,8 @@ jobs:
         image-tag: arm64
         commit-hash: ${{ env.COMMIT_HASH }}
         driver: ${{ steps.setup.outputs.driver }}
-        build-args: |
-          IMAGE_TAG=arm64
-          ARCH=arm64
-          EXTRA_APT_PACKAGES=netcat-openbsd
+        arch: arm64
+        extra-apt-packages: netcat-openbsd
 
     - name: Set up QEMU
       if: ${{ github.event_name == 'schedule' || inputs.build_type == 'all' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,16 @@
 ###############################################################################
 
 ARG IMAGE_TAG=stable
-FROM ghcr.io/rajanagori/nightingale_programming_image:${IMAGE_TAG} AS base
+# COPY --from=image:${ARG} does not expand. Name the GHCR images as stages first.
+FROM ghcr.io/rajanagori/nightingale_programming_image:${IMAGE_TAG} AS programming
+FROM ghcr.io/rajanagori/nightingale_web_vapt_image:${IMAGE_TAG} AS web_vapt
+FROM ghcr.io/rajanagori/nightingale_osint_tools_image:${IMAGE_TAG} AS osint
+FROM ghcr.io/rajanagori/nightingale_mobile_vapt_image:${IMAGE_TAG} AS mobile
+FROM ghcr.io/rajanagori/nightingale_network_vapt_image:${IMAGE_TAG} AS network
+FROM ghcr.io/rajanagori/nightingale_forensic_and_red_teaming:${IMAGE_TAG} AS forensic
+FROM ghcr.io/rajanagori/nightingale_wordlist_image:${IMAGE_TAG} AS wordlist
+
+FROM programming AS base
 
 ARG IMAGE_TAG
 ARG ARCH=amd64
@@ -75,14 +84,14 @@ ENV TOOLS_WEB_VAPT=/home/tools_web_vapt \
 
 ENV PATH="${PATH}:/home/.local/bin:${BINARIES}:/home/go/bin:${TOOLS_NETWORK_VAPT}/neo4j/bin"
 
-COPY --from=ghcr.io/rajanagori/nightingale_web_vapt_image:${IMAGE_TAG} ${TOOLS_WEB_VAPT} ${TOOLS_WEB_VAPT}
-COPY --from=ghcr.io/rajanagori/nightingale_web_vapt_image:${IMAGE_TAG} ${GREP_PATTERNS} ${GREP_PATTERNS}
-COPY --from=ghcr.io/rajanagori/nightingale_osint_tools_image:${IMAGE_TAG} ${TOOLS_OSINT} ${TOOLS_OSINT}
-COPY --from=ghcr.io/rajanagori/nightingale_mobile_vapt_image:${IMAGE_TAG} ${TOOLS_MOBILE_VAPT} ${TOOLS_MOBILE_VAPT}
-COPY --from=ghcr.io/rajanagori/nightingale_network_vapt_image:${IMAGE_TAG} ${TOOLS_NETWORK_VAPT} ${TOOLS_NETWORK_VAPT}
-COPY --from=ghcr.io/rajanagori/nightingale_forensic_and_red_teaming:${IMAGE_TAG} ${TOOLS_RED_TEAMING} ${TOOLS_RED_TEAMING}
-COPY --from=ghcr.io/rajanagori/nightingale_forensic_and_red_teaming:${IMAGE_TAG} ${TOOLS_FORENSICS} ${TOOLS_FORENSICS}
-COPY --from=ghcr.io/rajanagori/nightingale_wordlist_image:${IMAGE_TAG} ${WORDLIST} ${WORDLIST}
+COPY --from=web_vapt ${TOOLS_WEB_VAPT} ${TOOLS_WEB_VAPT}
+COPY --from=web_vapt ${GREP_PATTERNS} ${GREP_PATTERNS}
+COPY --from=osint ${TOOLS_OSINT} ${TOOLS_OSINT}
+COPY --from=mobile ${TOOLS_MOBILE_VAPT} ${TOOLS_MOBILE_VAPT}
+COPY --from=network ${TOOLS_NETWORK_VAPT} ${TOOLS_NETWORK_VAPT}
+COPY --from=forensic ${TOOLS_RED_TEAMING} ${TOOLS_RED_TEAMING}
+COPY --from=forensic ${TOOLS_FORENSICS} ${TOOLS_FORENSICS}
+COPY --from=wordlist ${WORDLIST} ${WORDLIST}
 
 ## Modules stage: Python tools plus vendored binaries. Go tools are installed
 ## once in the final stage (rebuild-go-binaries.sh) after /home/go is overlaid.
@@ -156,9 +165,9 @@ RUN set -eux; \
     rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/* 2>/dev/null || true; \
     find ${TOOLS_WEB_VAPT} ${TOOLS_OSINT} ${TOOLS_MOBILE_VAPT} ${TOOLS_NETWORK_VAPT} ${TOOLS_RED_TEAMING} ${TOOLS_FORENSICS} ${WORDLIST} -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true;
 
-COPY --from=ghcr.io/rajanagori/nightingale_programming_image:${IMAGE_TAG} /usr/local /usr/local
-COPY --from=ghcr.io/rajanagori/nightingale_programming_image:${IMAGE_TAG} /opt/venv3 /opt/venv3
-COPY --from=ghcr.io/rajanagori/nightingale_programming_image:${IMAGE_TAG} /usr/local/go /home/go
+COPY --from=programming /usr/local /usr/local
+COPY --from=programming /opt/venv3 /opt/venv3
+COPY --from=programming /usr/local/go /home/go
 
 RUN set -eux; \
     chmod +x /usr/local/bin/debian-apt-security.sh /usr/local/bin/pip-security-upgrade.sh; \


### PR DESCRIPTION
COPY --from=image:${ARG} is parsed as a stage name, so BuildKit left ${IMAGE_TAG} literal and the final image jobs died. Alias the GHCR images as stages first. Also stop passing the removed setup-buildx install input, and set Dockerfile args from image-tag in the composite.